### PR TITLE
Add chatbot and student dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ Feel free to fork the repo and suggest improvements or new features like:
 - Visual fraction bars
 - Practice quizzes
 
+## 🤖 Llama Chatbot Interface
+
+The repository includes `chatbot_app.py`, a small Flask application that provides
+a graphical interface for a locally installed Llama model. To use it:
+
+1. Install dependencies: `pip install flask transformers torch`.
+2. Download your Llama weights and set the environment variable
+   `LLAMA_MODEL_PATH` to that directory.
+3. Run `python chatbot_app.py` and open `http://localhost:5000` in a browser.
+4. From the chat page you can upload text files that may be useful for answering
+   questions.
+
+## 📊 Student Dashboard
+
+`dashboard.html` offers example learning activities to help students memorize
+terms, build concepts, and practice procedures. Access it directly or via the
+link at the bottom of `index.html`.
+
 ---
 
 ## License

--- a/chatbot_app.py
+++ b/chatbot_app.py
@@ -1,0 +1,77 @@
+import os
+from flask import Flask, request, render_template_string, send_from_directory
+from transformers import LlamaTokenizer, LlamaForCausalLM
+import torch
+
+MODEL_PATH = os.environ.get("LLAMA_MODEL_PATH", "./llama")
+
+app = Flask(__name__)
+
+# Load model and tokenizer once at startup
+try:
+    tokenizer = LlamaTokenizer.from_pretrained(MODEL_PATH)
+    model = LlamaForCausalLM.from_pretrained(MODEL_PATH)
+except Exception as e:
+    tokenizer = None
+    model = None
+    print(f"Could not load Llama model: {e}")
+
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+CHAT_TEMPLATE = """
+<!doctype html>
+<title>Llama Chatbot</title>
+<h2>Llama Chatbot</h2>
+<form method=post>
+  <textarea name=message rows=4 cols=50></textarea><br>
+  <input type=submit value=Send>
+</form>
+{% if response %}
+<p><strong>You:</strong> {{message}}</p>
+<p><strong>Llama:</strong> {{response}}</p>
+{% endif %}
+<p><a href="/upload">Upload Document</a></p>
+<p><a href="/dashboard">Student Dashboard</a></p>
+"""
+
+UPLOAD_TEMPLATE = """
+<!doctype html>
+<title>Upload Document</title>
+<h2>Upload Document</h2>
+<form method=post enctype=multipart/form-data>
+  <input type=file name=file>
+  <input type=submit value=Upload>
+</form>
+<p><a href="/">Back to Chat</a></p>
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def chat():
+    response = None
+    message = None
+    if request.method == 'POST':
+        message = request.form.get('message', '')
+        if tokenizer is None or model is None:
+            response = "Model not loaded. Check LLAMA_MODEL_PATH."
+        else:
+            input_ids = tokenizer.encode(message + tokenizer.eos_token, return_tensors='pt')
+            output_ids = model.generate(input_ids, max_new_tokens=100)
+            response = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    return render_template_string(CHAT_TEMPLATE, response=response, message=message)
+
+@app.route('/upload', methods=['GET', 'POST'])
+def upload_file():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if file:
+            file.save(os.path.join(UPLOAD_DIR, file.filename))
+            return f"Uploaded {file.filename}<br><a href='/upload'>Upload another</a>"
+    return render_template_string(UPLOAD_TEMPLATE)
+
+@app.route('/dashboard')
+def dashboard_page():
+    return send_from_directory('.', 'dashboard.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Student Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 700px; margin: 40px auto; line-height: 1.6; }
+    ul { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Student Dashboard</h1>
+  <p>This page suggests learning activities for mastering new terms, concepts, and procedures.</p>
+  <ul>
+    <li><strong>Flashcards:</strong> Practice key terms and definitions using spaced repetition.</li>
+    <li><strong>Self-quizzes:</strong> Test recall of important facts.</li>
+    <li><strong>Compare &amp; Contrast:</strong> Organize examples to identify similarities and differences.</li>
+    <li><strong>Categorization tasks:</strong> Group related ideas to build a conceptual framework.</li>
+    <li><strong>Procedure builder:</strong> Arrange rules step by step until you can perform them from memory.</li>
+  </ul>
+  <p><a href="index.html">Back to Fraction Tool</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -72,5 +72,6 @@
         `Step 4: Simplify: ${simpNum}/${simpDen}`;
     }
   </script>
+  <p><a href="dashboard.html">Student Dashboard</a></p>
 </body>
 </html>

--- a/main.py
+++ b/main.py
@@ -1,1 +1,6 @@
+"""Entry point for the fraction addition project.
+
+Run `python chatbot_app.py` to start the Llama chatbot web interface.
+"""
+
 print('Hello, this is the fraction addition program.')


### PR DESCRIPTION
## Summary
- add simple Flask `chatbot_app.py` to run a local Llama model
- create a `dashboard.html` page with suggested learning activities
- link the dashboard from `index.html`
- update `README` with instructions for the chatbot and dashboard
- note new entry-point comments in `main.py`

## Testing
- `python -m py_compile main.py chatbot_app.py`
- `python chatbot_app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68537511d1508327a2556d7278ee8580